### PR TITLE
default-backend: Fix image name

### DIFF
--- a/default-backend.yaml
+++ b/default-backend.yaml
@@ -21,7 +21,7 @@ spec:
         # Any image is permissible as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: registry.opensuse.org/devel/caasp/kubic-container/container_arm/kubic/default-http-backend:0.15.0 
+        image: registry.opensuse.org/devel/caasp/kubic-container/container/kubic/default-http-backend:0.15.0
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
YAML manifests should point to container build, not container_arm.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>